### PR TITLE
Remove final keyword

### DIFF
--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -8,6 +8,6 @@
 
 namespace Laminas\Twitter\Exception;
 
-final class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -8,6 +8,6 @@
 
 namespace Laminas\Twitter\Exception;
 
-final class DomainException extends \DomainException implements ExceptionInterface
+class DomainException extends \DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -8,6 +8,6 @@
 
 namespace Laminas\Twitter\Exception;
 
-final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidMediaException.php
+++ b/src/Exception/InvalidMediaException.php
@@ -10,6 +10,6 @@ namespace Laminas\Twitter\Exception;
 
 use RuntimeException;
 
-final class InvalidMediaException extends RuntimeException implements ExceptionInterface
+class InvalidMediaException extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/MediaUploadException.php
+++ b/src/Exception/MediaUploadException.php
@@ -10,6 +10,6 @@ namespace Laminas\Twitter\Exception;
 
 use RuntimeException;
 
-final class MediaUploadException extends RuntimeException implements ExceptionInterface
+class MediaUploadException extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -8,6 +8,6 @@
 
 namespace Laminas\Twitter\Exception;
 
-final class OutOfRangeException extends \OutOfRangeException implements ExceptionInterface
+class OutOfRangeException extends \OutOfRangeException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -8,6 +8,6 @@
 
 namespace Laminas\Twitter\Exception;
 
-final class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -11,7 +11,7 @@ namespace Laminas\Twitter;
 /**
  * Twitter Image Uploader
  */
-final class Image extends Media
+class Image extends Media
 {
     public function __construct(
         string $imageUrl,

--- a/src/RateLimit.php
+++ b/src/RateLimit.php
@@ -15,7 +15,7 @@ use function property_exists;
 /**
  * Representation of the Rate Limit Headers from Twitter.
  */
-final class RateLimit
+class RateLimit
 {
     /** @var int */
     private $limit;

--- a/src/Response.php
+++ b/src/Response.php
@@ -28,7 +28,7 @@ use function sprintf;
  * - proxying to elements of the decoded response via property overloading
  * - method for retrieving a RateLimit instance with derived rate-limit headers
  */
-final class Response
+class Response
 {
     /**
      * Empty body content that should not result in response population.

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -81,7 +81,7 @@ use const JSON_UNESCAPED_UNICODE;
  *
  * @see https://developer.twitter.com/en/docs/basics/counting-characters
  */
-final class Twitter
+class Twitter
 {
     /**
      * Base URI for all API calls

--- a/src/Video.php
+++ b/src/Video.php
@@ -11,7 +11,7 @@ namespace Laminas\Twitter;
 /**
  * Twitter Video Uploader
  */
-final class Video extends Media
+class Video extends Media
 {
     public function __construct(
         string $imageUrl,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes

### Description
> Suggestion: release `3.2.1` with the `final` removed, move the `final` modifier to `4.0.0`
> _Originally posted by @Ocramius in https://github.com/laminas/laminas-twitter/issues/12#issuecomment-832820291_

- Resolves #12 