### PR TITLE
Replace static with self

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -198,7 +198,7 @@ final class Twitter
         } elseif (isset($options['oauth_options'])) {
             $oauthOptions = $options['oauth_options'];
         }
-        $oauthOptions['siteUrl'] = static::OAUTH_BASE_URI;
+        $oauthOptions['siteUrl'] = self::OAUTH_BASE_URI;
 
         $httpClientOptions = [];
         if (isset($options['httpClientOptions'])) {
@@ -221,7 +221,7 @@ final class Twitter
             $oauthOptions['token'] = $accessToken;
             $this->setHttpClient($accessToken->getHttpClient(
                 $oauthOptions,
-                static::OAUTH_BASE_URI,
+                self::OAUTH_BASE_URI,
                 $httpClientOptions
             ));
             return;
@@ -1515,7 +1515,7 @@ final class Twitter
 
         // Reset on every request to prevent parameters leaking between them.
         $client->resetParameters();
-        $client->setUri(static::API_BASE_URI . $path . '.json');
+        $client->setUri(self::API_BASE_URI . $path . '.json');
 
         if (null === $this->cookieJar) {
             $client->clearCookies();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

### Description
> Psalm will never be able to reliably type `static::SOME_CONSTANT`... You can stop the issue a couple of ways...by changing `static` to `self`. See: https://github.com/vimeo/psalm/issues/505#issuecomment-364714367

- Resolves CI Errors for #13